### PR TITLE
fix: Revert removed Monitored Image

### DIFF
--- a/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
@@ -56,6 +56,10 @@ spec:
               value: {{ .Values.tests.rabbitIsManagedByOperator | quote }}
             - name: TAGS
               value: {{ default "smoke" .Values.tests.tags | quote }}
+            {{- if and .Values.deployDescriptor .Values.testsImage }}
+            - name: MONITORED_IMAGES
+              value: {{ include "rabbitmq.monitoredImages" . }}
+            {{- end }}
             {{- if .Values.tests.statusWritingEnabled }}
             - name: STATUS_WRITING_ENABLED
               value: {{ .Values.tests.statusWritingEnabled | quote }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Revert removed Monitored Image as part of https://github.com/Netcracker/qubership-rabbitmq/commit/896fd003a96751a9e7c6f788f857a90ab6f5408b#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cL59-R61

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
