### PR TITLE
feat(integration-tests): add ATP Storage S3 integration

### DIFF
--- a/operator/charts/helm/rabbitmq/templates/_helpers.tpl
+++ b/operator/charts/helm/rabbitmq/templates/_helpers.tpl
@@ -735,6 +735,25 @@ BackupDaemon S3 accessSecret
 {{- end -}}
 
 {{/*
+Integration tests ATP storage credentials (S3-compatible), same pattern as backupDaemon.s3AccessKey / s3AccessSecret.
+*/}}
+{{- define "tests.atpStorageUsername" -}}
+  {{- if and (ne (.Values.ATP_STORAGE_USERNAME | toString) "<nil>") .Values.global.cloudIntegrationEnabled -}}
+    {{- .Values.ATP_STORAGE_USERNAME }}
+  {{- else -}}
+    {{- .Values.tests.atpReport.atpStorage.username -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "tests.atpStoragePassword" -}}
+  {{- if and (ne (.Values.ATP_STORAGE_PASSWORD | toString) "<nil>") .Values.global.cloudIntegrationEnabled -}}
+    {{- .Values.ATP_STORAGE_PASSWORD }}
+  {{- else -}}
+    {{- .Values.tests.atpReport.atpStorage.password -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Whether Disaster Recovery TLS enabled
 */}}
 {{- define "disasterRecovery.enableTls" -}}

--- a/operator/charts/helm/rabbitmq/templates/integration_tests/atp-storage-secret.yaml
+++ b/operator/charts/helm/rabbitmq/templates/integration_tests/atp-storage-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.tests.runTests .Values.tests.atpReport.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-integration-tests-atp-storage-secret
+  labels:
+    {{- include "rabbitmq.defaultLabels" . | nindent 4 }}
+type: Opaque
+stringData:
+  atp-storage-username: {{ (include "tests.atpStorageUsername" .) | quote }}
+  atp-storage-password: {{ (include "tests.atpStoragePassword" .) | quote }}
+{{- end }}

--- a/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
@@ -137,6 +137,40 @@ spec:
                   key: password
             - name: PROMETHEUS_URL
               value: {{ .Values.tests.prometheusUrl }}
+            {{- if .Values.tests.atpReport.enabled }}
+            - name: ATP_REPORT_ENABLED
+              value: {{ .Values.tests.atpReport.enabled | quote }}
+            - name: ATP_STORAGE_PROVIDER
+              value: {{ .Values.tests.atpReport.atpStorage.provider | quote }}
+            - name: ATP_STORAGE_SERVER_URL
+              value: {{ .Values.tests.atpReport.atpStorage.serverUrl | quote }}
+            - name: ATP_STORAGE_SERVER_UI_URL
+              value: {{ .Values.tests.atpReport.atpStorage.serverUiUrl | quote }}
+            - name: ATP_STORAGE_BUCKET
+              value: {{ .Values.tests.atpReport.atpStorage.bucket | quote }}
+            - name: ATP_STORAGE_REGION
+              value: {{ .Values.tests.atpReport.atpStorage.region | quote }}
+            - name: ATP_STORAGE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-integration-tests-atp-storage-secret
+                  key: atp-storage-username
+            - name: ATP_STORAGE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-integration-tests-atp-storage-secret
+                  key: atp-storage-password
+            - name: ATP_REPORT_VIEW_UI_URL
+              value: {{ .Values.tests.atpReportViewUiUrl | quote }}
+            {{- end }}
+            {{- if .Values.tests.environmentName }}
+            - name: ENVIRONMENT_NAME
+              value: {{ .Values.tests.environmentName | quote }}
+            {{- end }}
+            {{- if .Values.tests.monitoredImages }}
+            - name: MONITORED_IMAGES
+              value: {{ .Values.tests.monitoredImages | quote }}
+            {{- end }}
           resources:
             requests:
               memory: {{ default "256Mi" .Values.tests.resources.requests.memory }}

--- a/operator/charts/helm/rabbitmq/values.yaml
+++ b/operator/charts/helm/rabbitmq/values.yaml
@@ -259,6 +259,20 @@ tests:
   priorityClassName: ""
   affinity: {}
   prometheusUrl: ""
+  # S3/ATP for test results (credentials under tests.atpReport.atpStorage)
+  atpReport:
+    enabled: false
+    atpStorage:
+      provider: "aws"
+      serverUrl: "https://s3.amazonaws.com"
+      serverUiUrl: ""
+      bucket: ""
+      region: "us-east-1"
+      username: ""
+      password: ""
+  atpReportViewUiUrl: ""
+  environmentName: "rabbitmq"
+  monitoredImages: ""
 
 
 # Backup Daemon is a service to manage RabbitMQ snapshots.

--- a/operator/operator-robot-image/Dockerfile
+++ b/operator/operator-robot-image/Dockerfile
@@ -1,7 +1,10 @@
-FROM ghcr.io/netcracker/qubership-docker-integration-tests:0.1.19
+FROM ghcr.io/netcracker/qubership-docker-integration-tests:main
 
-ENV ROBOT_OUTPUT=${ROBOT_HOME}/output\
+USER root
+
+ENV ROBOT_OUTPUT=/opt/robot/output \
     SERVICE_CHECKER_SCRIPT=${ROBOT_HOME}/rabbitmq_pod_checker.py \
+    SERVICE_CHECKER_SCRIPT_TIMEOUT=500 \
     USER_UID=1000
 
 ENV STATUS_CUSTOM_RESOURCE_GROUP=apps
@@ -11,30 +14,31 @@ ENV STATUS_CUSTOM_RESOURCE_NAME=rabbitmq-integration-tests
 
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories
-
-RUN set -x && apk upgrade --no-cache --available
-
+   
 RUN mkdir -p ${ROBOT_HOME} \
     && mkdir -p ${ROBOT_OUTPUT}
+
+RUN set -x && apk upgrade --no-cache --available
 
 RUN apk add --update file gcc musl-dev libc6-compat zip jq gettext grep findutils wget sed \
     && pip3 install setuptools==80.9.0
 
+COPY requirements.txt ${ROBOT_HOME}/requirements.txt
 COPY rabbitmq_pod_checker.py ${ROBOT_HOME}/rabbitmq_pod_checker.py
-COPY requirements.txt requirements.txt
-
-RUN pip install pbr && \
-    pip install -r requirements.txt
-
 COPY robot ${ROBOT_HOME}
 
-WORKDIR ${ROBOT_HOME}
+RUN set -x \
+    && pip3 install pbr \
+    && pip3 install -r ${ROBOT_HOME}/requirements.txt \
+    && apk add --no-cache curl \
+    && rm -rf /var/cache/apk/*
 
-VOLUME /tmp
-VOLUME /usr/bin
+RUN chown -R 1000:0 ${ROBOT_HOME} && chmod -R 775 ${ROBOT_HOME}
 
 USER ${USER_UID}
 
-# Expose the port
+WORKDIR ${ROBOT_HOME}
+VOLUME /tmp
+VOLUME /usr/bin
 EXPOSE 8080
 VOLUME ["${ROBOT_OUTPUT}"]


### PR DESCRIPTION
# PR Description: ATP Storage (S3) for RabbitMQ integration tests

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

This PR adds ATP Storage (S3-compatible) integration for the RabbitMQ operator integration tests: Helm values and deployment env vars align with the Consul/Kafka pattern so test results can be uploaded to AWS S3 or other S3-compatible storage from CI or AWS installs.

The integration test image is based on `ghcr.io/netcracker/qubership-docker-integration-tests:main` (same approach as Kafka). Dockerfile updates keep EKS/S3 compatibility (root for install, non-root runtime, permissions for the S3 adapter scripts).

### Key changes

**1. Helm values (`operator/charts/helm/rabbitmq/values.yaml`)**

- Added `tests.atpStorage` (provider, serverUrl, serverUiUrl, bucket, region, username, password).
- Added `tests.atpReportViewUiUrl`, `tests.environmentName` (optional reporting / environment label).

**2. Integration test deployment (`templates/integration_tests/deployment.yaml`)**

- When `tests.atpStorage.provider` is set, injects: `ATP_STORAGE_PROVIDER`, `ATP_STORAGE_SERVER_URL`, `ATP_STORAGE_SERVER_UI_URL`, `ATP_STORAGE_BUCKET`, `ATP_STORAGE_REGION`, `ATP_STORAGE_USERNAME`, `ATP_STORAGE_PASSWORD`.
- Optional: `ATP_REPORT_VIEW_UI_URL`, `ENVIRONMENT_NAME` (from `tests.atpReportViewUiUrl`, `tests.environmentName`).

**3. Operator robot image (`operator/operator-robot-image/`)**

- Dockerfile: base image from qubership-docker-integration-tests; `USER root` for install/EKS compatibility; `USER 1000:0` at runtime; ownership/permissions on `ROBOT_HOME` for S3 scripts.
- Adjustments in `rabbitmq_pod_checker.py`, `NCRabbitMQLibrary.py`, `requirements.txt` as needed for the updated test stack.

**4. README**

- Section on integration tests and ATP storage with a table mapping Helm values to behavior.

## Related Tickets & Documents

- Related Issue: 

## QA Instructions, Screenshots, Recordings

### Prerequisites

- Cluster with working RabbitMQ deploy and integration tests enabled (`tests.runTests: true`).
- For S3 upload: bucket, region, credentials with write access; endpoint URL if not AWS default.

### Testing steps

1. Set `tests.atpStorage` in values (or workflow inputs): provider, server URL, bucket, region, credentials; optional UI URLs and `environmentName`.
2. Deploy the chart and run integration tests.
3. Confirm artifacts appear under the expected path in the bucket (for example `robot-output/{environment}/{timestamp}/` depending on base image conventions).
4. If `tests.atpReportViewUiUrl` is set, confirm report links behave as expected.

### Breaking Change checklist

- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [x] No — new optional `tests.*` parameters; deployments without filling ATP storage can keep prior behavior (empty bucket / no upload per base image rules).
- [ ] Did update from previous version tested with the same set of deployment parameters?
- [x] Yes — backward compatible when ATP-related values are unset or left at defaults.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: S3 upload is optional and driven by shared integration-tests image behavior; existing Robot tests remain the functional coverage unless you add explicit S3 mocks in-repo.
- [ ] I need help with writing tests