### PR TITLE
fix: Tests without exclusions run twice

### DIFF
--- a/operator/operator-robot-image/Dockerfile
+++ b/operator/operator-robot-image/Dockerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/netcracker/qubership-docker-integration-tests:0.5.1
-
+FROM ghcr.io/netcracker/qubership-docker-integration-tests:0.5.3
 USER root
 
 ENV ROBOT_OUTPUT=/opt/robot/output \

--- a/operator/operator-robot-image/Dockerfile
+++ b/operator/operator-robot-image/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/netcracker/qubership-docker-integration-tests:0.5.3
+
 USER root
 
 ENV ROBOT_OUTPUT=/opt/robot/output \

--- a/operator/operator-robot-image/robot/tests/keywords.robot
+++ b/operator/operator-robot-image/robot/tests/keywords.robot
@@ -127,10 +127,10 @@ Change Rabbitmq Password With Function
 Get First Rabbit Pod
     ${rabbit_pods}=  Get Pods  ${NAMESPACE}
     ${pod_names}=  Get Pods By Mask  ${rabbit_pods}  rmqlocal
-    [Return]  ${pod_names[0]}
+    RETURN  ${pod_names[0]}
 
 Get Rabbit Replicas From Single Stateful Set
     [Arguments]  ${stateful_set_names}
     ${stateful_set_names}=  Set Variable  ${stateful_set_names[0]}
     ${replicas}=  Get Stateful Set Replicas Count  ${stateful_set_names}  ${NAMESPACE}
-    [Return]  ${replicas}
+    RETURN  ${replicas}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Ticket

CPCAP-10336

## Description

Tests without exclusions run twice. The fix is done in https://github.com/Netcracker/qubership-docker-integration-tests/pull/149.

What's done:
1) Update base docker image to fixed version.
2) [Return] -> RETURN.

Result:
```
Included tags: smokeORrabbitmq_images
Excluded tags: 
ATP report adapter disabled (ATP_REPORT_ENABLED!=true); running robot like upstream image
==============================================================================
Tests                                                                         
==============================================================================
Tests.Image Tests                                                             
==============================================================================
Tests.Image Tests.Image Tests                                                 
==============================================================================
Test Hardcoded Images                                                 
[COMPARE] deployment rabbitmq-operator rabbitmq-operator artifactory.netcracker.com:17152/netcracker/qubership-rabbitmq-operator:2.3.1: Expected tag = 2.3.1, Actual tag = 2.3.1
[COMPARE]  deployment rabbitmq-backup-daemon rabbitmq-backup-daemon artifactorycn.netcracker.com:17152/netcracker/qubership-rabbitmq-backup-daemon:2.3.1: Expected tag = 2.3.1, Actual tag = 2.3.1
[COMPARE]  statefulset rmqlocal rmqlocal artifactory.netcracker.com:17152/netcracker/qubership-rabbitmq-image:2.3.1: Expected tag = 2.3.1, Actual tag = 2.3.1
[COMPARE]  deployment rabbitmq-integration-tests rabbitmq-integration-tests artifactorycn.netcracker.com:17152/netcracker/qubership-rabbitmq-integration-tests:bugfix_tests_without_exclusions_run_twice: Expected tag = bugfix_tests_without_exclusions_run_twice, Actual tag = bugfix_tests_without_exclusions_run_twice
| PASS |
------------------------------------------------------------------------------
Tests.Image Tests.Image Tests                                         | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Image Tests                                                     | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Smoke                                                                   
==============================================================================
Tests.Smoke.Smoke                                                             
==============================================================================
Test Cluster                                                          | PASS |
------------------------------------------------------------------------------
Test Connection                                                       | PASS |
------------------------------------------------------------------------------
Create Queue, User And Vhost                                          | PASS |
------------------------------------------------------------------------------
[ ERROR ] _AsyncBaseTransport._produce() failed, aborting connection: error=ConnectionResetError(104, 'Connection reset by peer'); sock=<socket.socket fd=13, family=2, type=1, proto=6, laddr=('10.130.43.142', 56850)>; Caller's stack:
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
    ~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 819, in _produce
    num_bytes_sent = self._sigint_safe_send(self._sock,
                                            self._tx_buffers[0])
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 79, in retry_sigint_wrap
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 861, in _sigint_safe_send
    return sock.send(data)
           ~~~~~~~~~^^^^^^
ConnectionResetError: [Errno 104] Connection reset by peer
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 1103, in _on_socket_writable
    self._produce()
    ~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 819, in _produce
    num_bytes_sent = self._sigint_safe_send(self._sock,
                                            self._tx_buffers[0])
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 79, in retry_sigint_wrap
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/pika/adapters/utils/io_services_utils.py", line 861, in _sigint_safe_send
    return sock.send(data)
           ~~~~~~~~~^^^^^^
ConnectionResetError: [Errno 104] Connection reset by peer
[ ERROR ] connection_lost: StreamLostError: ("Stream connection lost: ConnectionResetError(104, 'Connection reset by peer')",)
[ ERROR ] Unexpected connection close detected: StreamLostError: ("Stream connection lost: ConnectionResetError(104, 'Connection reset by peer')",)
Tests.Smoke.Smoke                                                     | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests.Smoke                                                           | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Output:  /opt/robot/output/output.xml
Log:     /opt/robot/output/log.html
Report:  /opt/robot/output/report.html
Starting ttyd...
```