### PR TITLE
feat: container hardening

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -92,7 +92,7 @@ jobs:
           echo "platforms=$(jq -c '.platforms' ${CONFIG_FILE})" >> "$GITHUB_OUTPUT"
 
       - name: Create tags for images
-        uses: netcracker/qubership-workflow-hub/actions/metadata-action@396774180000abdb825cbf150b56cc59c6913db8  # v2.0.5
+        uses: netcracker/qubership-workflow-hub/actions/metadata-action@8d542a426ce561c7dce745f6b9cee068d1d7e101 #v2.0.10
         id: meta
         with:
           default-template: "{{ref-name}}"

--- a/.github/workflows/integration-rabbit-mq-build.yml
+++ b/.github/workflows/integration-rabbit-mq-build.yml
@@ -130,11 +130,11 @@ jobs:
 
   rabbit-mq-pipeline:
     needs: [update-image-reference, multiplatform_build]
-    uses: Netcracker/qubership-test-pipelines/.github/workflows/rabbitmq.yaml@4487afa083e5ba0cf64690d2e93e3d8ee94fab4f # v1.3.0
+    uses: Netcracker/qubership-test-pipelines/.github/workflows/rabbitmq.yaml@277bfa19072ddcbfe1e4df2253b9b70c61a1a68e # v1.13.1
     with:
       service_branch: "${{ needs.update-image-reference.outputs.TARGET_BRANCH }}"
       versions_file: ".github/versions.yaml"
-      pipeline_branch: "4487afa083e5ba0cf64690d2e93e3d8ee94fab4f" #this value must match the value after '@' in 'uses'
+      pipeline_branch: "277bfa19072ddcbfe1e4df2253b9b70c61a1a68e" #this value must match the value after '@' in 'uses'
     secrets:
       AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
       AWS_S3_ACCESS_KEY_SECRET: ${{ secrets.AWS_S3_ACCESS_KEY_SECRET }}

--- a/operator/build/entrypoint
+++ b/operator/build/entrypoint
@@ -4,5 +4,6 @@ if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
     echo "${USER_NAME:-operator}:x:$(id -u):$(id -g):${USER_NAME:-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
+  export USER="${USER_NAME:-operator}"
 fi
 exec "$@"

--- a/operator/charts/helm/rabbitmq/templates/_helpers.tpl
+++ b/operator/charts/helm/rabbitmq/templates/_helpers.tpl
@@ -326,6 +326,10 @@ runAsNonRoot: true
 {{- end }}
 seccompProfile:
   type: "RuntimeDefault"
+{{- if eq (default "" .Values.PAAS_PLATFORM) "KUBERNETES" }}
+runAsUser: 1000
+runAsGroup: 1000
+{{- end }}
 {{- with .Values.global.securityContext }}
 {{ toYaml . }}
 {{- end -}}
@@ -333,8 +337,20 @@ seccompProfile:
 
 {{- define "rabbitmq.globalContainerSecurityContext" -}}
 allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
 capabilities:
   drop: ["ALL"]
+{{- end -}}
+
+{{- define "rabbitmq.tmpVolume" -}}
+- name: tmp
+  emptyDir:
+    sizeLimit: {{ . }}
+{{- end -}}
+
+{{- define "rabbitmq.tmpVolumeMount" -}}
+- name: tmp
+  mountPath: /tmp
 {{- end -}}
 
 {{/*

--- a/operator/charts/helm/rabbitmq/templates/backup-daemon-deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/backup-daemon-deployment.yaml
@@ -31,6 +31,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
       {{- with .Values.global.customLabels }}
         {{- toYaml . | nindent 8 -}}
       {{- end }}
@@ -88,6 +89,7 @@ spec:
           secret:
             secretName: {{ template "rabbitmq.tlsSecretName" . }}
         {{- end }}
+        {{- include "rabbitmq.tmpVolume" "64Mi" | nindent 8 }}
       containers:
         - name: rabbitmq-backup-daemon
           image: {{ template "backupDaemon.image" . }}
@@ -160,25 +162,26 @@ spec:
                   key: s3-key-secret
             {{- end }}
           volumeMounts:
-        {{- if (eq (include "backupDaemon.enableTls" .) "true") }}
-          - name: backup-daemon-ssl-certs
-            mountPath: /backupTLS
-        {{- end }}
-        {{- if and (include "backupDaemon.s3.tlsSecretName" .) .Values.backupDaemon.s3.sslVerify .Values.backupDaemon.s3.enabled }}
-          - name: s3-ssl-certs
-            mountPath: /s3Certs
-        {{- end }}
-        {{- if $hasS3Aliases }}
-          - name: rabbitmq-backup-daemon-s3-aliases
-            mountPath: /aliases/
-            readOnly: true
-        {{- end }}
-          - name: backup-storage
-            mountPath: /opt/rabbitmq/backup-storage
-        {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
-          - name: ssl-certs
-            mountPath: /tls
-        {{- end }}
+            {{- include "rabbitmq.tmpVolumeMount" . | nindent 12 }}
+            {{- if (eq (include "backupDaemon.enableTls" .) "true") }}
+            - name: backup-daemon-ssl-certs
+              mountPath: /backupTLS
+            {{- end }}
+            {{- if and (include "backupDaemon.s3.tlsSecretName" .) .Values.backupDaemon.s3.sslVerify .Values.backupDaemon.s3.enabled }}
+            - name: s3-ssl-certs
+              mountPath: /s3Certs
+            {{- end }}
+            {{- if $hasS3Aliases }}
+            - name: rabbitmq-backup-daemon-s3-aliases
+              mountPath: /aliases/
+              readOnly: true
+            {{- end }}
+            - name: backup-storage
+              mountPath: /opt/rabbitmq/backup-storage
+            {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
+            - name: ssl-certs
+              mountPath: /tls
+            {{- end }}
           resources:
             requests:
               cpu: {{ default "25m" .Values.backupDaemon.resources.requests.cpu }}

--- a/operator/charts/helm/rabbitmq/templates/deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
       {{- with .Values.global.customLabels }}
         {{- toYaml . | nindent 8 -}}
       {{- end }}
@@ -39,8 +40,9 @@ spec:
       {{- if .Values.operator.priorityClassName }}
       priorityClassName: {{ .Values.operator.priorityClassName | quote }}
       {{- end }}
-      {{- if or (and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .)) (eq (include "disasterRecovery.enableTls" .) "true") (eq (include "backupDaemon.enableTls" .) "true") }}
       volumes:
+        {{- include "rabbitmq.tmpVolume" "8Mi" | nindent 8 }}
+      {{- if or (and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .)) (eq (include "disasterRecovery.enableTls" .) "true") (eq (include "backupDaemon.enableTls" .) "true") }}
       {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
         - name: ssl-certs
           secret:
@@ -135,8 +137,9 @@ spec:
             {{- end }}
             - name: API_GROUP
               value: {{ .Values.operator.apiGroup | quote }}
-        {{- if or (eq (include "backupDaemon.enableTls" .) "true") (and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .)) }}
           volumeMounts:
+            {{- include "rabbitmq.tmpVolumeMount" . | nindent 12 }}
+        {{- if or (eq (include "backupDaemon.enableTls" .) "true") (and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .)) }}
         {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
             - name: ssl-certs
               mountPath: /tls
@@ -150,8 +153,9 @@ spec:
         - name: rabbitmq-disaster-recovery
           image: {{ template "disasterRecovery.image" . }}
           imagePullPolicy: Always
-          {{- if (eq (include "disasterRecovery.enableTls" .) "true") }}
           volumeMounts:
+            {{- include "rabbitmq.tmpVolumeMount" . | nindent 12 }}
+          {{- if (eq (include "disasterRecovery.enableTls" .) "true") }}
             - name: drd-ssl-certs
               mountPath: /tls
           {{- end }}

--- a/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/integration_tests/deployment.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
       {{- with .Values.global.customLabels }}
         {{- toYaml . | nindent 8 -}}
       {{- end }}
@@ -61,6 +62,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: RABBIT_IS_MANAGED_BY_OPERATOR
               value: {{ .Values.tests.rabbitIsManagedByOperator | quote }}
+            - name: PART_OF
+              value: {{ .Values.PART_OF | quote }}
             - name: TAGS
               value: {{ default "smoke" .Values.tests.tags | quote }}
             {{- if and .Values.deployDescriptor .Values.testsImage }}
@@ -180,6 +183,8 @@ spec:
             - name: MONITORED_IMAGES
               value: {{ .Values.tests.monitoredImages | quote }}
             {{- end }}
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
           resources:
             requests:
               memory: {{ default "256Mi" .Values.tests.resources.requests.memory }}
@@ -190,6 +195,7 @@ spec:
           securityContext:
             {{- include "rabbitmq.globalContainerSecurityContext" . | nindent 12 }}
           volumeMounts:
+            {{- include "rabbitmq.tmpVolumeMount" . | nindent 12 }}
             - name: output
               mountPath: /opt/robot/output
           {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
@@ -220,6 +226,7 @@ spec:
       volumes:
         - name: output
           emptyDir: {}
+        {{- include "rabbitmq.tmpVolume" "32Mi" | nindent 8 }}
       {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}
         - name: ssl-certs
           secret:

--- a/operator/charts/helm/rabbitmq/templates/rabbit_monitoring_external_deployment.yaml
+++ b/operator/charts/helm/rabbitmq/templates/rabbit_monitoring_external_deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
         name: rabbit-monitoring-external
         app.kubernetes.io/name: rabbitmq-monitoring-external
     spec:
@@ -46,6 +47,7 @@ spec:
           secret:
             secretName: {{ template "rabbitmq.tlsSecretName" . }}
       {{- end }}
+        {{- include "rabbitmq.tmpVolume" "16Mi" | nindent 8 }}
       containers:
         - name: telegraf
           image: {{ template "telegraf.image" . }}
@@ -60,6 +62,8 @@ spec:
               containerPort: 8096
               protocol: TCP
           env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
             - name: OS_PROJECT
               valueFrom:
                 fieldRef:
@@ -82,6 +86,7 @@ spec:
             - name: DESIRED_NODE_COUNT
               value: "{{ .Values.externalRabbitmq.replicas }}"
           volumeMounts:
+            {{- include "rabbitmq.tmpVolumeMount" . | nindent 12 }}
             - name: config
               mountPath: /etc/telegraf
           {{- if and (eq (include "rabbitmq.enableTls" .) "true") (include "rabbitmq.tlsSecretName" .) }}

--- a/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
+++ b/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
@@ -23,7 +23,7 @@ data:
     log.upgrade.level = none
     log.console = true
     {{- if .Values.rabbitmq.eventLogging }}
-    management.load_definitions = /etc/rabbitmq/logging_definitions.json
+    management.load_definitions = /opt/rabbitmq/logging_definitions.json
     {{- end }}
     {{- include "rabbitmq.sslConfiguration" . | nindent 4}}
 

--- a/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
+++ b/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
@@ -23,7 +23,7 @@ data:
     log.upgrade.level = none
     log.console = true
     {{- if .Values.rabbitmq.eventLogging }}
-    management.load_definitions = /opt/rabbitmq/logging_definitions.json
+    management.load_definitions = /opt/rabbitmq/conf.d/logging_definitions.json
     {{- end }}
     {{- include "rabbitmq.sslConfiguration" . | nindent 4}}
 

--- a/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
+++ b/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: rabbitmq-config
 data:
   enabled_plugins: "{{ printf "[%s]." (include "rabbitmq.enabledPlugins" .) }}"
-  rabbitmq.conf: |-
+  rabbitmq.conf: |
     ## clustering
     {{- include "rabbitmq.clusterConfiguration" . | nindent 4}}
 
@@ -23,7 +23,7 @@ data:
     log.upgrade.level = none
     log.console = true
     {{- if .Values.rabbitmq.eventLogging }}
-    management.load_definitions = /etc/rabbitmq/logging_definitions.json
+    management.load_definitions = /tmp/logging_definitions.json
     {{- end }}
     {{- include "rabbitmq.sslConfiguration" . | nindent 4}}
 

--- a/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
+++ b/operator/charts/helm/rabbitmq/templates/rabbitmq-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: rabbitmq-config
 data:
   enabled_plugins: "{{ printf "[%s]." (include "rabbitmq.enabledPlugins" .) }}"
-  rabbitmq.conf: |-
+  rabbitmq.conf: |
     ## clustering
     {{- include "rabbitmq.clusterConfiguration" . | nindent 4}}
 
@@ -23,7 +23,7 @@ data:
     log.upgrade.level = none
     log.console = true
     {{- if .Values.rabbitmq.eventLogging }}
-    management.load_definitions = /opt/rabbitmq/conf.d/logging_definitions.json
+    management.load_definitions = /tmp/logging_definitions.json
     {{- end }}
     {{- include "rabbitmq.sslConfiguration" . | nindent 4}}
 

--- a/operator/charts/helm/rabbitmq/templates/restart-scheduler/cron-job.yaml
+++ b/operator/charts/helm/rabbitmq/templates/restart-scheduler/cron-job.yaml
@@ -19,6 +19,11 @@ spec:
       backoffLimit: 2
       activeDeadlineSeconds: 300
       template:
+        metadata:
+          labels:
+            {{- include "rabbitmq.defaultLabels" . | nindent 12 }}
+            app.kubernetes.io/name: rabbitmq-pod-restarter
+            name: rabbitmq-pod-restarter
         spec:
           securityContext:
             {{- include "rabbitmq.globalPodSecurityContext" . | nindent 12 }}

--- a/operator/charts/helm/rabbitmq/templates/status-provisioner/status-provisioner-cleanup-job.yaml
+++ b/operator/charts/helm/rabbitmq/templates/status-provisioner/status-provisioner-cleanup-job.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       name: rabbitmq-status-provisioner-cleanup
       labels:
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
         app: rabbitmq
         chart: rabbitmq
         release: {{ .Release.Name }}

--- a/operator/charts/helm/rabbitmq/templates/status-provisioner/status-provisioner-job.yaml
+++ b/operator/charts/helm/rabbitmq/templates/status-provisioner/status-provisioner-job.yaml
@@ -22,6 +22,7 @@ spec:
       {{- with .Values.statusProvisioner.customLabels }}
         {{- toYaml . | nindent 8 -}}
       {{- end }}
+        {{- include "rabbitmq.defaultLabels" . | nindent 8 }}
         app: rabbitmq
         chart: rabbitmq
         release: {{ .Release.Name }}
@@ -41,6 +42,8 @@ spec:
           image: {{ template "deployment-status-provisioner.image" . }}
           imagePullPolicy: "Always"
           env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/operator/charts/helm/rabbitmq/values.yaml
+++ b/operator/charts/helm/rabbitmq/values.yaml
@@ -446,3 +446,5 @@ PART_OF: "rabbitmq"
 DELIMITER: "-"
 # Artifact descriptor version which is installed.
 ARTIFACT_DESCRIPTOR_VERSION: ""  # TO_BE_REPLACED
+# Cloud Platform type
+PAAS_PLATFORM: "KUBERNETES"

--- a/operator/operator-robot-image/robot/tests/ha/ha.robot
+++ b/operator/operator-robot-image/robot/tests/ha/ha.robot
@@ -8,7 +8,8 @@ Suite Teardown  Cleanup HA Test Data
 *** Keywords ***
 
 Cleanup HA Test Data
-    Start Node If Stopped  ${first_pod}
+    ${pod_set}=  Run Keyword And Return Status  Variable Should Exist  ${first_pod}
+    Run Keyword If  '${pod_set}'=='True'  Start Node If Stopped  ${first_pod}
     Delete User If Exist
     Delete Vhost If Exist
     Delete Queue If Exist

--- a/operator/operator-robot-image/robot/tests/security_hardening/security_hardening_tests.robot
+++ b/operator/operator-robot-image/robot/tests/security_hardening/security_hardening_tests.robot
@@ -1,0 +1,23 @@
+# Copyright 2024-2025 NetCracker Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Library    PlatformLibrary    managed_by_operator=%{RABBIT_IS_MANAGED_BY_OPERATOR}
+
+*** Test Cases ***
+Test Container Hardening
+    [Tags]    rabbitmq    hardening
+    ${part_of}=    Create List    %{PART_OF}
+    ${exclusions}=    Create Dictionary    _all=CH12
+    Check Container Hardening    ${part_of}    %{NAMESPACE}    ${exclusions}

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -604,7 +604,8 @@ class KubernetesHelper:
             mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
                       V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
         mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
-        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/opt/rabbitmq'))
+        # Writable config dir only — never mount over /opt/rabbitmq (RABBITMQ_HOME / sbin).
+        mounts.append(V1VolumeMount(name='rabbitmq-conf', mount_path='/opt/rabbitmq/conf.d'))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -634,7 +635,7 @@ class KubernetesHelper:
     def get_volumes(self, pv_name):
         common_volumes = [
             V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='8Mi')),
-            V1Volume(name='rabbitmq-etc', empty_dir=V1EmptyDirVolumeSource(size_limit='10Mi')),
+            V1Volume(name='rabbitmq-conf', empty_dir=V1EmptyDirVolumeSource(size_limit='10Mi')),
         ]
         if self.is_hostpath():
             return [V1Volume(name=config_volume,

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -604,7 +604,7 @@ class KubernetesHelper:
             mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
                       V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
         mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
-        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/etc/rabbitmq'))
+        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/opt/rabbitmq'))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -937,7 +937,7 @@ class KubernetesHelper:
         if self.is_ipv6_enabled():
             pod_template_spec.spec.containers[0].env.extend(
                 [
-                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/etc/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
+                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/opt/rabbitmq/conf.d/erl_inetrc' -proto_dist inet6_tcp"),
                     V1EnvVar(name='RABBITMQ_CTL_ERL_ARGS', value="-proto_dist inet6_tcp"),
                 ]
             )

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -604,7 +604,7 @@ class KubernetesHelper:
             mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
                       V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
         mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
-        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/opt/rabbitmq/conf.d'))
+        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/etc/rabbitmq'))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -937,7 +937,7 @@ class KubernetesHelper:
         if self.is_ipv6_enabled():
             pod_template_spec.spec.containers[0].env.extend(
                 [
-                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/opt/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
+                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/etc/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
                     V1EnvVar(name='RABBITMQ_CTL_ERL_ARGS', value="-proto_dist inet6_tcp"),
                 ]
             )

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -597,15 +597,23 @@ class KubernetesHelper:
         return 'guest'
 
     def get_volume_mounts(self):
+        # ConfigMap keys mounted via subPath so image defaults under /etc/rabbitmq/conf.d stay visible.
+        mounts = [
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/rabbitmq.conf',
+                          sub_path='rabbitmq.conf', read_only=True),
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/enabled_plugins',
+                          sub_path='enabled_plugins', read_only=True),
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/advanced.config',
+                          sub_path='advanced.config', read_only=True),
+        ]
         if self.is_hostpath():
-            mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
-                      V1VolumeMount(name='rmqvolumedatamount', mount_path='/var/lib/rabbitmq')]
+            mounts.append(V1VolumeMount(name='rmqvolumedatamount', mount_path='/var/lib/rabbitmq'))
         else:
-            mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
-                      V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
+            mounts.append(V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq'))
         mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
-        # Writable config dir only — never mount over /opt/rabbitmq (RABBITMQ_HOME / sbin).
-        mounts.append(V1VolumeMount(name='rabbitmq-conf', mount_path='/opt/rabbitmq/conf.d'))
+        if self.is_ipv6_enabled():
+            mounts.append(V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/erl_inetrc',
+                                        sub_path='erl_inetrc', read_only=True))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -635,7 +643,6 @@ class KubernetesHelper:
     def get_volumes(self, pv_name):
         common_volumes = [
             V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='8Mi')),
-            V1Volume(name='rabbitmq-conf', empty_dir=V1EmptyDirVolumeSource(size_limit='10Mi')),
         ]
         if self.is_hostpath():
             return [V1Volume(name=config_volume,
@@ -938,7 +945,7 @@ class KubernetesHelper:
         if self.is_ipv6_enabled():
             pod_template_spec.spec.containers[0].env.extend(
                 [
-                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/opt/rabbitmq/conf.d/erl_inetrc' -proto_dist inet6_tcp"),
+                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/etc/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
                     V1EnvVar(name='RABBITMQ_CTL_ERL_ARGS', value="-proto_dist inet6_tcp"),
                 ]
             )

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -36,7 +36,8 @@ from kubernetes.client import V1ObjectMeta, V1EnvVar, V1Container, V1PodSpec, \
     V1StatefulSetUpdateStrategy, V1DeploymentStrategy, V1DeploymentSpec, \
     V1ComponentCondition, V1ComponentStatus, V1JobSpec, V1Job, \
     V1SecretVolumeSource, V1PodSecurityContext, \
-    V1SecurityContext, V1Capabilities, V1SeccompProfile, V1ContainerStateRunning, V1Probe
+    V1SecurityContext, V1Capabilities, V1SeccompProfile, V1ContainerStateRunning, V1Probe, \
+    V1EmptyDirVolumeSource
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 
@@ -230,7 +231,11 @@ class KubernetesHelper:
 
     @staticmethod
     def get_container_security_context():
-        return V1SecurityContext(allow_privilege_escalation=False, capabilities=V1Capabilities(drop=["ALL"]))
+        return V1SecurityContext(
+            allow_privilege_escalation=False,
+            read_only_root_filesystem=True,
+            capabilities=V1Capabilities(drop=["ALL"])
+        )
 
     def get_affinity_rules(self):
         affinity = self._spec['rabbitmq'].get('affinity')
@@ -598,6 +603,8 @@ class KubernetesHelper:
         else:
             mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
                       V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
+        mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
+        mounts.append(V1VolumeMount(name='rabbitmq-etc', mount_path='/opt/rabbitmq/conf.d'))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -625,6 +632,10 @@ class KubernetesHelper:
                                                     requests={'storage': self._res['storage']})))]
 
     def get_volumes(self, pv_name):
+        common_volumes = [
+            V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='8Mi')),
+            V1Volume(name='rabbitmq-etc', empty_dir=V1EmptyDirVolumeSource(size_limit='10Mi')),
+        ]
         if self.is_hostpath():
             return [V1Volume(name=config_volume,
                              config_map=V1ConfigMapVolumeSource(name=configmap_name,
@@ -633,13 +644,13 @@ class KubernetesHelper:
                                                                                          V1KeyToPath(key='advanced.config', path='advanced.config')])),
                     V1Volume(name='rmqvolumedatamount',
                              persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
-                                 claim_name=f'{pv_name}-rmq-pvc'))]
+                                 claim_name=f'{pv_name}-rmq-pvc'))] + common_volumes
         else:
             return [V1Volume(name=config_volume,
                              config_map=V1ConfigMapVolumeSource(name=configmap_name,
                                                                 default_mode=420, items=[V1KeyToPath(key='rabbitmq.conf', path='rabbitmq.conf'),
                                                                                          V1KeyToPath(key='enabled_plugins', path='enabled_plugins'),
-                                                                                         V1KeyToPath(key='advanced.config', path='advanced.config')]))]
+                                                                                         V1KeyToPath(key='advanced.config', path='advanced.config')]))] + common_volumes
 
     def generate_telegraf_deployment_config_body(self):
         telegraf_resources = V1ResourceRequirements(limits={'cpu': '100m', 'memory': '100Mi'},
@@ -723,7 +734,9 @@ class KubernetesHelper:
                                                    resources=telegraf_resources,
                                                    security_context=self.get_container_security_context(),
                                                    readiness_probe=readiness,
-                                                   liveness_probe=liveness,)],
+                                                   liveness_probe=liveness,
+                                                   volume_mounts=[V1VolumeMount(name='tmp', mount_path='/tmp')])],
+                           volumes=[V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='16Mi'))],
                            security_context=self.get_security_context("telegraf"),
                            affinity=self.get_affinity_rules(),
                            tolerations=self.get_tolerations(),
@@ -924,7 +937,7 @@ class KubernetesHelper:
         if self.is_ipv6_enabled():
             pod_template_spec.spec.containers[0].env.extend(
                 [
-                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/etc/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
+                    V1EnvVar(name='RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS', value="-kernel inetrc '/opt/rabbitmq/erl_inetrc' -proto_dist inet6_tcp"),
                     V1EnvVar(name='RABBITMQ_CTL_ERL_ARGS', value="-proto_dist inet6_tcp"),
                 ]
             )

--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -36,7 +36,8 @@ from kubernetes.client import V1ObjectMeta, V1EnvVar, V1Container, V1PodSpec, \
     V1StatefulSetUpdateStrategy, V1DeploymentStrategy, V1DeploymentSpec, \
     V1ComponentCondition, V1ComponentStatus, V1JobSpec, V1Job, \
     V1SecretVolumeSource, V1PodSecurityContext, \
-    V1SecurityContext, V1Capabilities, V1SeccompProfile, V1ContainerStateRunning, V1Probe
+    V1SecurityContext, V1Capabilities, V1SeccompProfile, V1ContainerStateRunning, V1Probe, \
+    V1EmptyDirVolumeSource
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 
@@ -230,7 +231,11 @@ class KubernetesHelper:
 
     @staticmethod
     def get_container_security_context():
-        return V1SecurityContext(allow_privilege_escalation=False, capabilities=V1Capabilities(drop=["ALL"]))
+        return V1SecurityContext(
+            allow_privilege_escalation=False,
+            read_only_root_filesystem=True,
+            capabilities=V1Capabilities(drop=["ALL"])
+        )
 
     def get_affinity_rules(self):
         affinity = self._spec['rabbitmq'].get('affinity')
@@ -592,12 +597,23 @@ class KubernetesHelper:
         return 'guest'
 
     def get_volume_mounts(self):
+        # ConfigMap keys mounted via subPath so image defaults under /etc/rabbitmq/conf.d stay visible.
+        mounts = [
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/rabbitmq.conf',
+                          sub_path='rabbitmq.conf', read_only=True),
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/enabled_plugins',
+                          sub_path='enabled_plugins', read_only=True),
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/advanced.config',
+                          sub_path='advanced.config', read_only=True),
+        ]
         if self.is_hostpath():
-            mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
-                      V1VolumeMount(name='rmqvolumedatamount', mount_path='/var/lib/rabbitmq')]
+            mounts.append(V1VolumeMount(name='rmqvolumedatamount', mount_path='/var/lib/rabbitmq'))
         else:
-            mounts = [V1VolumeMount(name=config_volume, mount_path='/configmap'),
-                      V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq')]
+            mounts.append(V1VolumeMount(name=vct_name, mount_path='/var/lib/rabbitmq'))
+        mounts.append(V1VolumeMount(name='tmp', mount_path='/tmp'))
+        if self.is_ipv6_enabled():
+            mounts.append(V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/erl_inetrc',
+                                        sub_path='erl_inetrc', read_only=True))
         if self.is_ssl_enabled():
             mounts.append(V1VolumeMount(name=ssl_volume, mount_path='/tls'))
         if self.is_ldap_enabled():
@@ -625,6 +641,9 @@ class KubernetesHelper:
                                                     requests={'storage': self._res['storage']})))]
 
     def get_volumes(self, pv_name):
+        common_volumes = [
+            V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='8Mi')),
+        ]
         if self.is_hostpath():
             return [V1Volume(name=config_volume,
                              config_map=V1ConfigMapVolumeSource(name=configmap_name,
@@ -633,13 +652,13 @@ class KubernetesHelper:
                                                                                          V1KeyToPath(key='advanced.config', path='advanced.config')])),
                     V1Volume(name='rmqvolumedatamount',
                              persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
-                                 claim_name=f'{pv_name}-rmq-pvc'))]
+                                 claim_name=f'{pv_name}-rmq-pvc'))] + common_volumes
         else:
             return [V1Volume(name=config_volume,
                              config_map=V1ConfigMapVolumeSource(name=configmap_name,
                                                                 default_mode=420, items=[V1KeyToPath(key='rabbitmq.conf', path='rabbitmq.conf'),
                                                                                          V1KeyToPath(key='enabled_plugins', path='enabled_plugins'),
-                                                                                         V1KeyToPath(key='advanced.config', path='advanced.config')]))]
+                                                                                         V1KeyToPath(key='advanced.config', path='advanced.config')]))] + common_volumes
 
     def generate_telegraf_deployment_config_body(self):
         telegraf_resources = V1ResourceRequirements(limits={'cpu': '100m', 'memory': '100Mi'},
@@ -723,7 +742,9 @@ class KubernetesHelper:
                                                    resources=telegraf_resources,
                                                    security_context=self.get_container_security_context(),
                                                    readiness_probe=readiness,
-                                                   liveness_probe=liveness,)],
+                                                   liveness_probe=liveness,
+                                                   volume_mounts=[V1VolumeMount(name='tmp', mount_path='/tmp')])],
+                           volumes=[V1Volume(name='tmp', empty_dir=V1EmptyDirVolumeSource(size_limit='16Mi'))],
                            security_context=self.get_security_context("telegraf"),
                            affinity=self.get_affinity_rules(),
                            tolerations=self.get_tolerations(),

--- a/rabbitmq-docker/3.13/Dockerfile
+++ b/rabbitmq-docker/3.13/Dockerfile
@@ -13,9 +13,6 @@ RUN set -x \
         "https://github.com/amazon-mq/rabbitmq-queue-migration/releases/download/${RABBITMQ_QUEUE_MIGRATION_VERSION}/rabbitmq_queue_migration-${RABBITMQ_QUEUE_MIGRATION_VERSION}.ez"
 
 ENV USER_UID=1000
-ENV RABBITMQ_CONFIG_FILES=/opt/rabbitmq/conf.d
-ENV RABBITMQ_ADVANCED_CONFIG_FILE=/opt/rabbitmq/conf.d/advanced.config
-ENV RABBITMQ_ENABLED_PLUGINS_FILE=/opt/rabbitmq/conf.d/enabled_plugins
 
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories
@@ -27,10 +24,9 @@ RUN apk add --no-cache \
     --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
     libssl3=3.5.7-r0 libcrypto3=3.5.7-r0
 
-RUN ln -sf usr/local/bin/docker-entrypoint.sh && \
+RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
 mkdir -p /var/log/rabbitmq && \
 chmod -R  777 /var/log/rabbitmq && \
-chmod -R  777 /etc/rabbitmq && \
 chmod +x /bin/change_password && \
 chmod +x /bin/get_user && \
 chmod +x /bin/get_password && \
@@ -46,9 +42,8 @@ RUN set -x \
     && pip3 install --upgrade pip "setuptools==80.10.1" \
     && rm -rf /var/cache/apk/*
 
-COPY logging_definitions.json /opt/rabbitmq/
+COPY logging_definitions.json /etc/rabbitmq/
 
-VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/3.13/Dockerfile
+++ b/rabbitmq-docker/3.13/Dockerfile
@@ -13,6 +13,9 @@ RUN set -x \
         "https://github.com/amazon-mq/rabbitmq-queue-migration/releases/download/${RABBITMQ_QUEUE_MIGRATION_VERSION}/rabbitmq_queue_migration-${RABBITMQ_QUEUE_MIGRATION_VERSION}.ez"
 
 ENV USER_UID=1000
+ENV RABBITMQ_CONFIG_FILES=/opt/rabbitmq/conf.d
+ENV RABBITMQ_ADVANCED_CONFIG_FILE=/opt/rabbitmq/conf.d/advanced.config
+ENV RABBITMQ_ENABLED_PLUGINS_FILE=/opt/rabbitmq/conf.d/enabled_plugins
 
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories && \
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories
@@ -43,7 +46,7 @@ RUN set -x \
     && pip3 install --upgrade pip "setuptools==80.10.1" \
     && rm -rf /var/cache/apk/*
 
-COPY logging_definitions.json /etc/rabbitmq/
+COPY logging_definitions.json /opt/rabbitmq/
 
 VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq

--- a/rabbitmq-docker/3.13/Dockerfile
+++ b/rabbitmq-docker/3.13/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
 RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
 mkdir -p /var/log/rabbitmq && \
 chmod -R  777 /var/log/rabbitmq && \
+chmod -R  777 /etc/rabbitmq && \
 chmod +x /bin/change_password && \
 chmod +x /bin/get_user && \
 chmod +x /bin/get_password && \
@@ -44,6 +45,7 @@ RUN set -x \
 
 COPY logging_definitions.json /etc/rabbitmq/
 
+VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/3.13/Dockerfile
+++ b/rabbitmq-docker/3.13/Dockerfile
@@ -24,10 +24,9 @@ RUN apk add --no-cache \
     --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
     libssl3=3.5.7-r0 libcrypto3=3.5.7-r0
 
-RUN ln -sf usr/local/bin/docker-entrypoint.sh && \
+RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
 mkdir -p /var/log/rabbitmq && \
 chmod -R  777 /var/log/rabbitmq && \
-chmod -R  777 /etc/rabbitmq && \
 chmod +x /bin/change_password && \
 chmod +x /bin/get_user && \
 chmod +x /bin/get_password && \
@@ -45,7 +44,6 @@ RUN set -x \
 
 COPY logging_definitions.json /etc/rabbitmq/
 
-VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/4.0/Dockerfile
+++ b/rabbitmq-docker/4.0/Dockerfile
@@ -8,6 +8,9 @@ COPY scripts/get_password /bin/
 COPY scripts/change_password /bin/
 
 ENV USER_UID=1000
+ENV RABBITMQ_CONFIG_FILES=/opt/rabbitmq/conf.d
+ENV RABBITMQ_ADVANCED_CONFIG_FILE=/opt/rabbitmq/conf.d/advanced.config
+ENV RABBITMQ_ENABLED_PLUGINS_FILE=/opt/rabbitmq/conf.d/enabled_plugins
 
 # Upgrade tools from edge to avoid vulnerabilities
 RUN apk add --no-cache \
@@ -16,19 +19,17 @@ RUN apk add --no-cache \
 
 RUN set -x && apk upgrade --no-cache --available
 
-RUN ln -sf usr/local/bin/docker-entrypoint.sh && \
+RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
     mkdir -p /var/log/rabbitmq && \
-    chmod -R  777 /var/log/rabbitmq && \
-    chmod -R  777 /etc/rabbitmq && \
+    chmod -R 777 /var/log/rabbitmq && \
     chmod +x /bin/change_password && \
     chmod +x /bin/get_user && \
     chmod +x /bin/get_password && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
-    chmod -R  a+r /opt/rabbitmq/plugins
+    chmod -R a+r /opt/rabbitmq/plugins
 
-COPY logging_definitions.json /etc/rabbitmq/
+COPY logging_definitions.json /opt/rabbitmq/
 
-VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/4.0/Dockerfile
+++ b/rabbitmq-docker/4.0/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x && apk upgrade --no-cache --available
 RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
     mkdir -p /var/log/rabbitmq && \
     chmod -R 777 /var/log/rabbitmq && \
+    chmod -R  777 /etc/rabbitmq && \
     chmod +x /bin/change_password && \
     chmod +x /bin/get_user && \
     chmod +x /bin/get_password && \
@@ -27,6 +28,7 @@ RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
 
 COPY logging_definitions.json /etc/rabbitmq/
 
+VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/4.0/Dockerfile
+++ b/rabbitmq-docker/4.0/Dockerfile
@@ -16,19 +16,17 @@ RUN apk add --no-cache \
 
 RUN set -x && apk upgrade --no-cache --available
 
-RUN ln -sf usr/local/bin/docker-entrypoint.sh && \
+RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
     mkdir -p /var/log/rabbitmq && \
-    chmod -R  777 /var/log/rabbitmq && \
-    chmod -R  777 /etc/rabbitmq && \
+    chmod -R 777 /var/log/rabbitmq && \
     chmod +x /bin/change_password && \
     chmod +x /bin/get_user && \
     chmod +x /bin/get_password && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
-    chmod -R  a+r /opt/rabbitmq/plugins
+    chmod -R a+r /opt/rabbitmq/plugins
 
 COPY logging_definitions.json /etc/rabbitmq/
 
-VOLUME /etc/rabbitmq
 VOLUME /var/log/rabbitmq
 VOLUME /tmp
 

--- a/rabbitmq-docker/4.0/Dockerfile
+++ b/rabbitmq-docker/4.0/Dockerfile
@@ -8,9 +8,6 @@ COPY scripts/get_password /bin/
 COPY scripts/change_password /bin/
 
 ENV USER_UID=1000
-ENV RABBITMQ_CONFIG_FILES=/opt/rabbitmq/conf.d
-ENV RABBITMQ_ADVANCED_CONFIG_FILE=/opt/rabbitmq/conf.d/advanced.config
-ENV RABBITMQ_ENABLED_PLUGINS_FILE=/opt/rabbitmq/conf.d/enabled_plugins
 
 # Upgrade tools from edge to avoid vulnerabilities
 RUN apk add --no-cache \
@@ -28,7 +25,7 @@ RUN ln -sf /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh && \
     chmod -R a+r /opt/rabbitmq/plugins
 
-COPY logging_definitions.json /opt/rabbitmq/
+COPY logging_definitions.json /etc/rabbitmq/
 
 VOLUME /var/log/rabbitmq
 VOLUME /tmp

--- a/rabbitmq-docker/docker-entrypoint.sh
+++ b/rabbitmq-docker/docker-entrypoint.sh
@@ -6,9 +6,13 @@ set -eu
 
 echo 'Using Custom Entrypoint'
 
-cp /configmap/* /etc/rabbitmq
-echo -e "\n" >> /etc/rabbitmq/rabbitmq.conf
-echo "Configs were copied to the /etc/rabbitmq folder."
+# Static config is mounted via subPath into /etc/rabbitmq (image conf.d stays intact).
+# logging_definitions.json needs sed under readOnlyRootFilesystem -> prepare a copy in /tmp.
+if [ -f /etc/rabbitmq/logging_definitions.json ]; then
+	cp /etc/rabbitmq/logging_definitions.json /tmp/logging_definitions.json
+fi
+
+echo "Configs are ready."
 
 # Diff from community version - we need this if to be able to clean PVs
 if [[ -f /var/lib/rabbitmq/delete_all ]]; then
@@ -82,9 +86,9 @@ if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ];
 fi
 
 # replace username and password inside definition using credentials from ENV
-if [ -f /etc/rabbitmq/logging_definitions.json ]; then
-    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /etc/rabbitmq/logging_definitions.json
-    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /etc/rabbitmq/logging_definitions.json
+if [ -f /tmp/logging_definitions.json ]; then
+    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /tmp/logging_definitions.json
+    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /tmp/logging_definitions.json
 fi
 
 

--- a/rabbitmq-docker/docker-entrypoint.sh
+++ b/rabbitmq-docker/docker-entrypoint.sh
@@ -6,9 +6,13 @@ set -eu
 
 echo 'Using Custom Entrypoint'
 
-cp /configmap/* /etc/rabbitmq
-echo -e "\n" >> /etc/rabbitmq/rabbitmq.conf
-echo "Configs were copied to the /etc/rabbitmq folder."
+mkdir -p /opt/rabbitmq/conf.d
+# Copy RabbitMQ configuration
+cp -r /etc/rabbitmq/. /opt/rabbitmq/
+cp /configmap/* /opt/rabbitmq/conf.d/
+echo -e "\n" >> /opt/rabbitmq/conf.d/rabbitmq.conf
+
+echo "Configs were copied."
 
 # Diff from community version - we need this if to be able to clean PVs
 if [[ -f /var/lib/rabbitmq/delete_all ]]; then
@@ -82,9 +86,9 @@ if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ];
 fi
 
 # replace username and password inside definition using credentials from ENV
-if [ -f /etc/rabbitmq/logging_definitions.json ]; then
-    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /etc/rabbitmq/logging_definitions.json
-    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /etc/rabbitmq/logging_definitions.json
+if [ -f /opt/rabbitmq/logging_definitions.json ]; then
+    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /opt/rabbitmq/logging_definitions.json
+    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /opt/rabbitmq/logging_definitions.json
 fi
 
 

--- a/rabbitmq-docker/docker-entrypoint.sh
+++ b/rabbitmq-docker/docker-entrypoint.sh
@@ -6,9 +6,26 @@ set -eu
 
 echo 'Using Custom Entrypoint'
 
+# Runtime config directory (RABBITMQ_CONFIG_FILES / RABBITMQ_*_FILE point here).
+# Under readOnlyRootFilesystem this path is an emptyDir; do not write into RABBITMQ_HOME (/opt/rabbitmq).
 mkdir -p /opt/rabbitmq/conf.d
-# Copy RabbitMQ configuration
-cp -r /etc/rabbitmq/. /opt/rabbitmq/
+
+# Copy all default files from the image config dir so upgrades that add files under
+# /etc/rabbitmq are picked up without mixing configs into the installation tree.
+if [ -d /etc/rabbitmq/conf.d ]; then
+	cp -a /etc/rabbitmq/conf.d/. /opt/rabbitmq/conf.d/
+fi
+for f in /etc/rabbitmq/*; do
+	if [ -f "$f" ]; then
+		cp -a "$f" /opt/rabbitmq/conf.d/
+	fi
+done
+
+# Definitions are baked into the image (read-only); copy before sed under ROFS.
+if [ -f /opt/rabbitmq/logging_definitions.json ]; then
+	cp /opt/rabbitmq/logging_definitions.json /opt/rabbitmq/conf.d/
+fi
+
 cp /configmap/* /opt/rabbitmq/conf.d/
 echo -e "\n" >> /opt/rabbitmq/conf.d/rabbitmq.conf
 
@@ -86,9 +103,9 @@ if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ];
 fi
 
 # replace username and password inside definition using credentials from ENV
-if [ -f /opt/rabbitmq/logging_definitions.json ]; then
-    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /opt/rabbitmq/logging_definitions.json
-    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /opt/rabbitmq/logging_definitions.json
+if [ -f /opt/rabbitmq/conf.d/logging_definitions.json ]; then
+    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /opt/rabbitmq/conf.d/logging_definitions.json
+    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /opt/rabbitmq/conf.d/logging_definitions.json
 fi
 
 

--- a/rabbitmq-docker/docker-entrypoint.sh
+++ b/rabbitmq-docker/docker-entrypoint.sh
@@ -6,30 +6,13 @@ set -eu
 
 echo 'Using Custom Entrypoint'
 
-# Runtime config directory (RABBITMQ_CONFIG_FILES / RABBITMQ_*_FILE point here).
-# Under readOnlyRootFilesystem this path is an emptyDir; do not write into RABBITMQ_HOME (/opt/rabbitmq).
-mkdir -p /opt/rabbitmq/conf.d
-
-# Copy all default files from the image config dir so upgrades that add files under
-# /etc/rabbitmq are picked up without mixing configs into the installation tree.
-if [ -d /etc/rabbitmq/conf.d ]; then
-	cp -a /etc/rabbitmq/conf.d/. /opt/rabbitmq/conf.d/
-fi
-for f in /etc/rabbitmq/*; do
-	if [ -f "$f" ]; then
-		cp -a "$f" /opt/rabbitmq/conf.d/
-	fi
-done
-
-# Definitions are baked into the image (read-only); copy before sed under ROFS.
-if [ -f /opt/rabbitmq/logging_definitions.json ]; then
-	cp /opt/rabbitmq/logging_definitions.json /opt/rabbitmq/conf.d/
+# Static config is mounted via subPath into /etc/rabbitmq (image conf.d stays intact).
+# logging_definitions.json needs sed under readOnlyRootFilesystem -> prepare a copy in /tmp.
+if [ -f /etc/rabbitmq/logging_definitions.json ]; then
+	cp /etc/rabbitmq/logging_definitions.json /tmp/logging_definitions.json
 fi
 
-cp /configmap/* /opt/rabbitmq/conf.d/
-echo -e "\n" >> /opt/rabbitmq/conf.d/rabbitmq.conf
-
-echo "Configs were copied."
+echo "Configs are ready."
 
 # Diff from community version - we need this if to be able to clean PVs
 if [[ -f /var/lib/rabbitmq/delete_all ]]; then
@@ -103,9 +86,9 @@ if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ];
 fi
 
 # replace username and password inside definition using credentials from ENV
-if [ -f /opt/rabbitmq/conf.d/logging_definitions.json ]; then
-    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /opt/rabbitmq/conf.d/logging_definitions.json
-    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /opt/rabbitmq/conf.d/logging_definitions.json
+if [ -f /tmp/logging_definitions.json ]; then
+    sed -i -e 's/username_to_replace/'${RABBITMQ_DEFAULT_USER}'/g' /tmp/logging_definitions.json
+    sed -i -e 's/password_to_replace/'${RABBITMQ_DEFAULT_PASS}'/g' /tmp/logging_definitions.json
 fi
 
 

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -1,6 +1,7 @@
 FROM telegraf:1.39.1-alpine
 
 ENV RABBITMQ_MONITORING_HOME=/opt/rabbitmq-monitoring \
+    MONITORING_LOGS=/tmp/monitoring/logs \
     USER_UID=1000
 
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositories && \
@@ -40,5 +41,4 @@ WORKDIR ${RABBITMQ_MONITORING_HOME}
 
 USER ${USER_UID}
 
-ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]
-CMD ["telegraf"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh", "telegraf"]

--- a/telegraf/exec-scripts/prometheus.py
+++ b/telegraf/exec-scripts/prometheus.py
@@ -31,6 +31,7 @@ import queue_parser
 logger = logging.getLogger(__name__)
 
 CA_CERT_PATH = '/tls/ca.crt'
+MONITORING_LOGS = os.getenv('MONITORING_LOGS')
 
 
 def suppress_errors(return_func=lambda: []):
@@ -147,16 +148,17 @@ def get_prometheus_metrics(metrics):
 
 def __configure_logging(log):
     log.setLevel(logging.DEBUG)
+    os.makedirs(MONITORING_LOGS, exist_ok=True)
     formatter = logging.Formatter(fmt='[%(asctime)s,%(msecs)03d][%(levelname)s] %(message)s',
                                   datefmt='%Y-%m-%dT%H:%M:%S')
 
-    log_handler = RotatingFileHandler(filename='/opt/rabbitmq-monitoring/exec-scripts/rabbitmq_metric.log',
+    log_handler = RotatingFileHandler(filename=f'{MONITORING_LOGS}/rabbitmq_metric.log',
                                       maxBytes=50 * 1024,
                                       backupCount=5)
     log_handler.setFormatter(formatter)
     log_handler.setLevel(logging.DEBUG if os.getenv('RABBITMQ_MONITORING_SCRIPT_DEBUG') else logging.INFO)
     log.addHandler(log_handler)
-    err_handler = RotatingFileHandler(filename='/opt/rabbitmq-monitoring/exec-scripts/rabbitmq_metric.err',
+    err_handler = RotatingFileHandler(filename=f'{MONITORING_LOGS}/rabbitmq_metric.err',
                                       maxBytes=50 * 1024,
                                       backupCount=5)
     err_handler.setFormatter(formatter)

--- a/telegraf/exec-scripts/version_info.py
+++ b/telegraf/exec-scripts/version_info.py
@@ -27,6 +27,7 @@ from prometheus_client import Gauge
 logger = logging.getLogger(__name__)
 
 CA_CERT_PATH = '/tls/ca.crt'
+MONITORING_LOGS = os.getenv('MONITORING_LOGS')
 
 
 class RetryExhaustedError(IOError):
@@ -89,14 +90,15 @@ def prometheus_formatted_metrics(version):
 def __configure_logging(log):
 
     log.setLevel(logging.DEBUG)
+    os.makedirs(MONITORING_LOGS, exist_ok=True)
     formatter = logging.Formatter(fmt='[%(asctime)s,%(msecs)03d][%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
 
-    log_handler = RotatingFileHandler(filename='/opt/rabbitmq-monitoring/exec-scripts/version_info.log', maxBytes=50 * 1024, backupCount=5)
+    log_handler = RotatingFileHandler(filename=f'{MONITORING_LOGS}/version_info.log', maxBytes=50 * 1024, backupCount=5)
     log_handler.setFormatter(formatter)
     log_handler.setLevel(logging.DEBUG if os.getenv('RABBITMQ_MONITORING_SCRIPT_DEBUG') else logging.INFO)
     log.addHandler(log_handler)
 
-    err_handler = RotatingFileHandler(filename='/opt/rabbitmq-monitoring/exec-scripts/version_info.err', maxBytes=50 * 1024, backupCount=5)
+    err_handler = RotatingFileHandler(filename=f'{MONITORING_LOGS}/version_info.err', maxBytes=50 * 1024, backupCount=5)
     err_handler.setFormatter(formatter)
     err_handler.setLevel(logging.ERROR)
     log.addHandler(err_handler)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request introduces several security hardening improvements, configuration enhancements, and workflow updates for the RabbitMQ operator and its associated Helm charts and test suites. The main focus is on enforcing stricter container security, improving temporary storage management, and ensuring consistent labeling and configuration across deployments.

**Security and Hardening Improvements:**

* Enforce `readOnlyRootFilesystem: true` and drop all Linux capabilities in the global container security context in the Helm templates and Python handler, reducing container attack surface. [[1]](diffhunk://#diff-c14364c4701de70708654d1fad38b6f468a4d892219b02466e9d245bd184c7f3R329-R355) [[2]](diffhunk://#diff-a14f34f5779aafed17c6c0a2121c86bca698ae408e02de0bf899c20f95e7f88dL233-R238)
* Add and mount a dedicated `/tmp` volume with size limits for all major deployments (operator, backup-daemon, integration tests, monitoring), ensuring no writes to the root filesystem. [[1]](diffhunk://#diff-c14364c4701de70708654d1fad38b6f468a4d892219b02466e9d245bd184c7f3R329-R355) [[2]](diffhunk://#diff-ab83c77d5d57a950931acbe56a64a4ffd882eb3afa009ba2d77584ae5287fd5bL42-R45) [[3]](diffhunk://#diff-ab83c77d5d57a950931acbe56a64a4ffd882eb3afa009ba2d77584ae5287fd5bL138-R142) [[4]](diffhunk://#diff-ab83c77d5d57a950931acbe56a64a4ffd882eb3afa009ba2d77584ae5287fd5bL153-R158) [[5]](diffhunk://#diff-bd37b3070e5f35f3e0267662027812cad824fa802c091f7b19e3a275e048c218R92) [[6]](diffhunk://#diff-bd37b3070e5f35f3e0267662027812cad824fa802c091f7b19e3a275e048c218R165) [[7]](diffhunk://#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cR198) [[8]](diffhunk://#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cR229) [[9]](diffhunk://#diff-1866c31bd9912180d3caa73e911589a3d9319ae5b2a8e4f3459e12f4ad741adcR50) [[10]](diffhunk://#diff-1866c31bd9912180d3caa73e911589a3d9319ae5b2a8e4f3459e12f4ad741adcR89)
* Update `rabbitmq.conf` to load event logging definitions from `/tmp/logging_definitions.json` instead of the root filesystem.

**Labeling and Configuration Consistency:**

* Add `rabbitmq.defaultLabels` to all deployments, jobs, and cron jobs to standardize resource labeling. [[1]](diffhunk://#diff-ab83c77d5d57a950931acbe56a64a4ffd882eb3afa009ba2d77584ae5287fd5bR22) [[2]](diffhunk://#diff-bd37b3070e5f35f3e0267662027812cad824fa802c091f7b19e3a275e048c218R34) [[3]](diffhunk://#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cR29) [[4]](diffhunk://#diff-1866c31bd9912180d3caa73e911589a3d9319ae5b2a8e4f3459e12f4ad741adcR21) [[5]](diffhunk://#diff-53e9b189679ffc1436d8b5a8988a88a002a3b4e2b2909a5c83c120b16c185ee7R22-R26) [[6]](diffhunk://#diff-c4a7d1f2c16edf5b07ad3affd4ac1e8a896b6cf1d897c57ff5ebea92febab4c2R22) [[7]](diffhunk://#diff-8fe460bb85e7abe8a78338ed2d29d05bb50fb545b8612f232251d98e62e3cc52R25)
* Expose `PAAS_PLATFORM` and `PART_OF` as configurable values in `values.yaml` and environment variables for deployments and tests. [[1]](diffhunk://#diff-7d7879db6a21356f66cde53110f43aa4f00600c6090cde63b8862a08c59a8232R449-R450) [[2]](diffhunk://#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cR65-R66)

**Workflow and Dependency Updates:**

* Update workflow actions and test pipeline references to latest versions for improved reliability and features. [[1]](diffhunk://#diff-2ace50007d05636bdbb4ee32251052be22a3bcb9f01108e2cbb7a2df05abc36eL95-R95) [[2]](diffhunk://#diff-20e745ac72889301f52965b4af3434647b660c13f56c918b95106edc66113a0fL133-R137)

**Testing Enhancements:**

* Add a new Robot Framework test suite, `security_hardening_tests.robot`, to verify container hardening compliance.
* Set `PYTHONDONTWRITEBYTECODE=1` in test and monitoring containers to prevent Python from writing `.pyc` files, supporting read-only filesystems. [[1]](diffhunk://#diff-38407d0de845a282735b6a661188399c9cc2a34737f08d97ff08c148ee70d86cR186-R187) [[2]](diffhunk://#diff-1866c31bd9912180d3caa73e911589a3d9319ae5b2a8e4f3459e12f4ad741adcR65-R66) [[3]](diffhunk://#diff-8fe460bb85e7abe8a78338ed2d29d05bb50fb545b8612f232251d98e62e3cc52R45-R46)

**Other Improvements:**

* Ensure the effective user is set in the container entrypoint script for environments where `/etc/passwd` may be modified.
* Fix a test robustness issue in `ha.robot` by checking if a variable is set before using it.

These changes collectively harden the deployment, improve maintainability, and ensure compliance with container security best practices.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue # CPCAP-9370
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
