### PR TITLE
fix: add config mount

### DIFF
--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -601,6 +601,8 @@ class KubernetesHelper:
         mounts = [
             V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/rabbitmq.conf',
                           sub_path='rabbitmq.conf', read_only=True),
+            V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/conf.d/20-operator.conf',
+                          sub_path='rabbitmq.conf', read_only=True),
             V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/enabled_plugins',
                           sub_path='enabled_plugins', read_only=True),
             V1VolumeMount(name=config_volume, mount_path='/etc/rabbitmq/advanced.config',
@@ -668,7 +670,7 @@ class KubernetesHelper:
                                                     requests={'cpu': '100m', 'memory': '100Mi'})
 
         telegraf_image = self._spec['telegraf']['dockerImage']
-        image_pull_policy = 'Always' if 'latest' in telegraf_image.lower() \
+        image_pull_policy = 'Always' if 'main' in telegraf_image.lower() or 'latest' in telegraf_image.lower() \
             else 'IfNotPresent'
 
         pod_envs = [
@@ -1912,7 +1914,7 @@ def on_update_secret(diff, **kwargs):
     else:
         logger.info("changing password...")
         kub_helper.change_password()
-    sleep(30)
+    sleep(65)
     logger.info("rebooting all pods in rabbitmq namespace")
     v1_apps_api = client.CoreV1Api()
     pods = v1_apps_api.list_namespaced_pod(namespace)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

RabbitMQ 3.13 only loads config from conf.d/ — it ignores /etc/rabbitmq/rabbitmq.conf. Without this mount, cluster formation nodes aren't loaded each pod starts standalone  cluster never forms.
 Kubelet's sync period + TTL cache = up to 60s delay. sleep time updated sleep(65)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
