### PR TITLE
fix: exclude RabbitMQ stateful set from Velero backups

### DIFF
--- a/operator/src/handler.py
+++ b/operator/src/handler.py
@@ -890,6 +890,7 @@ class KubernetesHelper:
         sts_labels["name"] = "rabbitmq"
         sts_labels["app.kubernetes.io/name"] = "rabbitmq"
         sts_labels["app.kubernetes.io/instance"] = f'rabbitmq-{self._workspace}'
+        sts_labels["velero.io/exclude-from-backup"] = "true"
         meta = V1ObjectMeta(labels=sts_labels, name=name, namespace=self._workspace)
         rabbitmq_image = self._spec['rabbitmq']['dockerImage']
         image_pull_policy = 'Always' if 'main' in rabbitmq_image.lower() else 'IfNotPresent'


### PR DESCRIPTION
Added a label to the RabbitMQ stateful set to prevent it from being included in Velero backups, ensuring that backup processes do not interfere with RabbitMQ's state management.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
